### PR TITLE
Fix isCurrent and order of calls in updateBounds after reset

### DIFF
--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -599,6 +599,9 @@ void SpatioTemporalVoxelLayer::reset(void)
 
   current_ = false;
   was_reset_ = true;
+
+  // @kin-changes (costmap-clearance-issue): Reseting the _last_updated (ResetLastUpdatedTime) of the individual observation buffers was removed,
+  //  since the buffers are not reset in this process either.
 }
 
 /*****************************************************************************/
@@ -673,6 +676,7 @@ void SpatioTemporalVoxelLayer::updateCosts(
   // set was_reset to false again
   if (!current_ && was_reset_) {
     was_reset_ = false;
+    // @kin-changes (costmap-clearance-issue): don't force current_ to be true here
   }
 
   if (_update_footprint_enabled) {
@@ -767,6 +771,8 @@ void SpatioTemporalVoxelLayer::updateBounds(
   }
 
   // mark observations
+  // @kin-changes (costmap-clearance-issue): this was moved before the call to ClearFrustums, to include the
+  //  new markings within one update cycle
   _voxel_grid->Mark(marking_observations);
 
   // save map or clear frustrums and populate costmap


### PR DESCRIPTION
Slightly change the order of subcalls in the `updateBounds`method, to assure that new readings are included in the costmap within a single update cycle. Furthermore, fix `isCurrent` logic to only report true if the costmap is really current (also after a reset).