### PR TITLE
Measurement buffer does not remove old observations if no observations are retrieved anymore

### DIFF
--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -218,7 +218,7 @@ void MeasurementBuffer::RemoveStaleObservations(void)
   }
 
   for (it = _observation_list.begin(); it != _observation_list.end(); ++it) {
-    const rclcpp::Duration time_diff = _last_updated - it->_cloud->header.stamp;
+    const rclcpp::Duration time_diff = clock_->now() - it->_cloud->header.stamp;
 
     if (time_diff > _observation_keep_time) {
       _observation_list.erase(it, _observation_list.end());

--- a/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
+++ b/spatio_temporal_voxel_layer/src/spatio_temporal_voxel_layer.cpp
@@ -599,6 +599,9 @@ void SpatioTemporalVoxelLayer::reset(void)
 
   current_ = false;
   was_reset_ = true;
+
+  // @kin-changes (costmap-clearance-issue): Reseting the _last_updated (ResetLastUpdatedTime) of the individual observation buffers was removed,
+  //  since the buffers are not reset in this process either.
 }
 
 /*****************************************************************************/
@@ -673,6 +676,7 @@ void SpatioTemporalVoxelLayer::updateCosts(
   // set was_reset to false again
   if (!current_ && was_reset_) {
     was_reset_ = false;
+    // @kin-changes (costmap-clearance-issue): don't force current_ to be true here
   }
 
   if (_update_footprint_enabled) {
@@ -767,6 +771,8 @@ void SpatioTemporalVoxelLayer::updateBounds(
   }
 
   // mark observations
+  // @kin-changes (costmap-clearance-issue): this was moved before the call to ClearFrustums, to include the
+  //  new markings within one update cycle
   _voxel_grid->Mark(marking_observations);
 
   // save map or clear frustrums and populate costmap


### PR DESCRIPTION
Change the check in `RemoveStaleObservations` such that it considers the age of the received data instead of when the data was received relative to the last received data.