### PR TITLE
Measurement buffer does not remove old observations if we stop to retrieve observations

### DIFF
--- a/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
+++ b/spatio_temporal_voxel_layer/src/measurement_buffer.cpp
@@ -218,7 +218,7 @@ void MeasurementBuffer::RemoveStaleObservations(void)
   }
 
   for (it = _observation_list.begin(); it != _observation_list.end(); ++it) {
-    const rclcpp::Duration time_diff = _last_updated - it->_cloud->header.stamp;
+    const rclcpp::Duration time_diff = clock_->now() - it->_cloud->header.stamp;
 
     if (time_diff > _observation_keep_time) {
       _observation_list.erase(it, _observation_list.end());


### PR DESCRIPTION
Change the check in `RemoveStaleObservations` such that it considers the age of the received data instead of when the data was received relative to the last received data.

Here the corresponding issue we raised in the official stvl repo: https://github.com/SteveMacenski/spatio_temporal_voxel_layer/issues/307